### PR TITLE
fixes #3: wrong version of geckodriver used for win64

### DIFF
--- a/src/Selenium.WebDriver.GeckoDriver.nuspec
+++ b/src/Selenium.WebDriver.GeckoDriver.nuspec
@@ -64,7 +64,7 @@
   </metadata>
   <files>
     <file src="..\downloads\win32\geckodriver.exe" target="driver/win32"/>
-    <file src="..\downloads\win32\geckodriver.exe" target="driver/win64"/>
+    <file src="..\downloads\win64\geckodriver.exe" target="driver/win64"/>
     <file src="..\downloads\macos\geckodriver" target="driver/mac64/geckodriver"/>
     <file src="..\downloads\linux64\geckodriver" target="driver/linux64/geckodriver"/>
     <file src="Selenium.WebDriver.GeckoDriver.targets" target="build"/>

--- a/src/Selenium.WebDriver.GeckoDriver.nuspec
+++ b/src/Selenium.WebDriver.GeckoDriver.nuspec
@@ -3,9 +3,9 @@
   <metadata>
     <id>Selenium.WebDriver.GeckoDriver</id>
     <title>Selenium.WebDriver.GeckoDriver (Win32, macOS, and Linux64)</title>
-    <version>0.23.0.0</version>
+    <version>0.23.1.0</version>
     <authors>jsakamoto</authors>
-    <summary>Selenium Gecko Driver (Win32, macOS, and Linux64) (does not make your source repository too fat.)</summary>
+    <summary>Selenium Gecko Driver (Win32, Win64, macOS, and Linux64) (does not make your source repository too fat.)</summary>
     <description>
       Install Gecko Driver (Win32, macOS, and Linux64) for Selenium WebDriver into your Unit Test Project.
       "geckodriver(.exe)" is copied to bin folder from package folder when the build process.
@@ -22,6 +22,8 @@
     <tags>Selenium WebDriver geckodriver firefox</tags>
     <releaseNotes>
       <![CDATA[
+      v.0.23.1
+      - Installing Win64 driver on 64bit Windows OS
       v.0.23.0
       - Gecko Driver 0.23.0 release
       v.0.22.0
@@ -62,6 +64,7 @@
   </metadata>
   <files>
     <file src="..\downloads\win32\geckodriver.exe" target="driver/win32"/>
+    <file src="..\downloads\win32\geckodriver.exe" target="driver/win64"/>
     <file src="..\downloads\macos\geckodriver" target="driver/mac64/geckodriver"/>
     <file src="..\downloads\linux64\geckodriver" target="driver/linux64/geckodriver"/>
     <file src="Selenium.WebDriver.GeckoDriver.targets" target="build"/>

--- a/src/Selenium.WebDriver.GeckoDriver.targets
+++ b/src/Selenium.WebDriver.GeckoDriver.targets
@@ -1,4 +1,4 @@
-<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">  
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <!-- Detect OS platform -->
   <PropertyGroup>
     <WebDriverPlatform Condition=" '$(WebDriverPlatform)' == '' And '$(OS)' == 'Windows_NT' And '$(PROCESSOR_ARCHITECTURE)' == 'x86' ">win32</WebDriverPlatform>
@@ -15,7 +15,7 @@
     <GeckoDriverTargetDir Condition=" '$(GeckoDriverTargetDir)' == '' ">$(TargetDir)</GeckoDriverTargetDir>
   </PropertyGroup>
 
-  <Target Name="ChmodGeckoDriver" BeforeTargets="BeforeBuild" Condition="'$(WebDriverPlatform)' == 'mac64' Or $(WebDriverPlatform)' == 'linux64'">
+  <Target Name="ChmodGeckoDriver" BeforeTargets="BeforeBuild" Condition="'$(WebDriverPlatform)' == 'mac64' Or '$(WebDriverPlatform)' == 'linux64'">
     <Exec Command="chmod +x &quot;$(GeckoDriverSrcPath)&quot;" />
   </Target>
 

--- a/src/Selenium.WebDriver.GeckoDriver.targets
+++ b/src/Selenium.WebDriver.GeckoDriver.targets
@@ -1,12 +1,13 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">  
   <!-- Detect OS platform -->
   <PropertyGroup>
-    <WebDriverPlatform Condition=" '$(WebDriverPlatform)' == '' And '$(OS)' == 'Windows_NT' ">win32</WebDriverPlatform>
+    <WebDriverPlatform Condition=" '$(WebDriverPlatform)' == '' And '$(OS)' == 'Windows_NT' And '$(PROCESSOR_ARCHITECTURE) == 'x86' ">win32</WebDriverPlatform>
+    <WebDriverPlatform Condition=" '$(WebDriverPlatform)' == '' And '$(OS)' == 'Windows_NT' And '$(PROCESSOR_ARCHITECTURE) == 'AMD64' ">win64</WebDriverPlatform>
     <WebDriverPlatform Condition=" '$(WebDriverPlatform)' == '' And '$(OS)' == 'Unix' And Exists ('/Applications') ">mac64</WebDriverPlatform>
     <WebDriverPlatform Condition=" '$(WebDriverPlatform)' == '' And '$(OS)' == 'Unix' ">linux64</WebDriverPlatform>
   </PropertyGroup>
   <PropertyGroup>
-    <GeckoDriverName Condition="'$(WebDriverPlatform)' == 'win32'">geckodriver.exe</GeckoDriverName>
+    <GeckoDriverName Condition="'$(WebDriverPlatform)' == 'win32' Or $(WebDriverPlatform)' == 'win64' ">geckodriver.exe</GeckoDriverName>
     <GeckoDriverName Condition="'$(GeckoDriverName)' == ''">geckodriver</GeckoDriverName>
   </PropertyGroup>
   <PropertyGroup>
@@ -14,7 +15,7 @@
     <GeckoDriverTargetDir Condition=" '$(GeckoDriverTargetDir)' == '' ">$(TargetDir)</GeckoDriverTargetDir>
   </PropertyGroup>
 
-  <Target Name="ChmodGeckoDriver" BeforeTargets="BeforeBuild" Condition="'$(WebDriverPlatform)' != 'win32'">
+  <Target Name="ChmodGeckoDriver" BeforeTargets="BeforeBuild" Condition="'$(WebDriverPlatform)' == 'mac64' Or $(WebDriverPlatform)' == 'linux64'">
     <Exec Command="chmod +x &quot;$(GeckoDriverSrcPath)&quot;" />
   </Target>
 

--- a/src/Selenium.WebDriver.GeckoDriver.targets
+++ b/src/Selenium.WebDriver.GeckoDriver.targets
@@ -1,13 +1,13 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">  
   <!-- Detect OS platform -->
   <PropertyGroup>
-    <WebDriverPlatform Condition=" '$(WebDriverPlatform)' == '' And '$(OS)' == 'Windows_NT' And '$(PROCESSOR_ARCHITECTURE) == 'x86' ">win32</WebDriverPlatform>
-    <WebDriverPlatform Condition=" '$(WebDriverPlatform)' == '' And '$(OS)' == 'Windows_NT' And '$(PROCESSOR_ARCHITECTURE) == 'AMD64' ">win64</WebDriverPlatform>
+    <WebDriverPlatform Condition=" '$(WebDriverPlatform)' == '' And '$(OS)' == 'Windows_NT' And '$(PROCESSOR_ARCHITECTURE)' == 'x86' ">win32</WebDriverPlatform>
+    <WebDriverPlatform Condition=" '$(WebDriverPlatform)' == '' And '$(OS)' == 'Windows_NT' And '$(PROCESSOR_ARCHITECTURE)' == 'AMD64' ">win64</WebDriverPlatform>
     <WebDriverPlatform Condition=" '$(WebDriverPlatform)' == '' And '$(OS)' == 'Unix' And Exists ('/Applications') ">mac64</WebDriverPlatform>
     <WebDriverPlatform Condition=" '$(WebDriverPlatform)' == '' And '$(OS)' == 'Unix' ">linux64</WebDriverPlatform>
   </PropertyGroup>
   <PropertyGroup>
-    <GeckoDriverName Condition="'$(WebDriverPlatform)' == 'win32' Or $(WebDriverPlatform)' == 'win64' ">geckodriver.exe</GeckoDriverName>
+    <GeckoDriverName Condition="'$(WebDriverPlatform)' == 'win32' Or '$(WebDriverPlatform)' == 'win64' ">geckodriver.exe</GeckoDriverName>
     <GeckoDriverName Condition="'$(GeckoDriverName)' == ''">geckodriver</GeckoDriverName>
   </PropertyGroup>
   <PropertyGroup>


### PR DESCRIPTION
Updated the general nuget package to include the win64 driver and updated the msbuild target to use it. This fixes #3.